### PR TITLE
Refactor logger to console/error service

### DIFF
--- a/PLANNING.md
+++ b/PLANNING.md
@@ -4,7 +4,7 @@
 This document outlines the refactoring performed to improve modularity, error handling and developer onboarding.
 
 ### Key Changes
-- Added centralized error logging via `src/lib/logger.ts` writing to `logs/debug.md`.
+- Added centralized error logging via `src/lib/logger.ts` which logs to the console or an external service.
 - Updated async functions and API routes to capture errors using `logError`.
 - Created `.env.example` with required configuration variables.
 - Provided page and component templates under `templates/`.

--- a/TASK.md
+++ b/TASK.md
@@ -15,5 +15,5 @@
 
 ## Handling Errors
 - [ ] Wrap async operations in try/catch.
-- [ ] Call `logError(file, functionName, error)` to record details in `logs/debug.md`.
+- [ ] Call `logError(file, functionName, error)` to output errors to the console or a logging service.
 - [ ] Surface user-friendly messages in the UI.

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,13 +1,18 @@
-import { appendFileSync } from 'fs'
-import path from 'path'
-
 export function logError(file: string, fn: string, error: unknown) {
   const timestamp = new Date().toISOString()
-  const message = `[${timestamp}] ${file}#${fn}: ${String(error)}\n`
-  const logPath = path.join(process.cwd(), 'logs', 'debug.md')
-  try {
-    appendFileSync(logPath, message)
-  } catch (err) {
-    console.error('Failed to write to log file:', err)
+  const message = `[${timestamp}] ${file}#${fn}: ${String(error)}`
+
+  // Always log to the server console for visibility during development
+  console.error(message)
+
+  // Optionally forward the error to an external logging endpoint
+  if (process.env.LOGGING_ENDPOINT) {
+    fetch(process.env.LOGGING_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message })
+    }).catch(err => {
+      console.error('Failed to send error to logging service:', err)
+    })
   }
 }


### PR DESCRIPTION
## Summary
- rewrite `logError` to output to console and optional logging endpoint
- update docs to reflect new logger behavior

## Testing
- `npm run lint` *(fails: next not found)*