### PR TITLE
Remove unused Google env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,4 @@
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
-GOOGLE_CLIENT_ID=your_google_client_id
-GOOGLE_CLIENT_SECRET=your_google_client_secret
 DEEPSEEK_API_URL=https://api.deepseek.com
 DEEPSEEK_API_KEY=your_deepseek_api_key

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ A Next.js application for AI-powered guidance.
    ```
    NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
    NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
-   GOOGLE_CLIENT_ID=your_google_client_id
-   GOOGLE_CLIENT_SECRET=your_google_client_secret
    ```
 4. Run the development server:
    ```bash


### PR DESCRIPTION
## Summary
- delete obsolete Google OAuth env vars from `.env.example`
- update `README` to remove references to those vars

## Testing
- `npm run lint` *(fails: `next` not found)*