### PR TITLE
Add uuid-ossp extension to migration

### DIFF
--- a/supabase/migrations/20240320000000_initial_schema.sql
+++ b/supabase/migrations/20240320000000_initial_schema.sql
@@ -1,3 +1,4 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 -- Create profiles table
 CREATE TABLE profiles (
   id UUID REFERENCES auth.users ON DELETE CASCADE,


### PR DESCRIPTION
## Summary
- enable `uuid-ossp` extension in the initial schema migration

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: Exit handler never called)*