### PR TITLE
Update README for DeepSeek vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ A Next.js application for AI-powered guidance.
    ```
    NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
    NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+   DEEPSEEK_API_URL=https://api.deepseek.com
+   DEEPSEEK_API_KEY=your_deepseek_api_key
    ```
    ```bash
    npm run dev


### PR DESCRIPTION
## Summary
- add `DEEPSEEK_API_URL` and `DEEPSEEK_API_KEY` to the env var list in README

## Testing
- `npm run lint` *(fails: next not found)*