### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ src/
 2. Create your feature branch
 3. Commit your changes
 4. Push to the branch
-5. Create a new Pull Request 
+5. Create a new Pull Request.


### PR DESCRIPTION
## Summary
- fix trailing command prompt text in README
- end Contributing section with a period and newline

## Testing
- `npm run lint` *(fails: next not found)*