### PR TITLE
Improve theme toggle with icons and button styles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,24 +6,58 @@
   body {
     @apply bg-white text-gray-900 antialiased;
   }
-  html.theme-grey body {
-    @apply bg-gray-100 text-gray-900;
+
+  /* Theme color variables */
+  html.theme-light {
+    --btn-primary-bg: #2563EB; /* blue-600 */
+    --btn-primary-hover: #1D4ED8; /* blue-700 */
+    --btn-secondary-bg: #ffffff;
+    --btn-secondary-hover: #f3f4f6; /* gray-100 */
+    --btn-secondary-text: #1F2937; /* gray-800 */
   }
-  html.theme-dark body {
+
+  html.theme-dark {
     @apply bg-gray-900 text-white;
+    --btn-primary-bg: #000000; /* cursor black */
+    --btn-primary-hover: #111827; /* gray-900 */
+    --btn-secondary-bg: #374151; /* gray-700 */
+    --btn-secondary-hover: #4b5563; /* gray-600 */
+    --btn-secondary-text: #f3f4f6; /* gray-100 */
+  }
+
+  html.theme-grey {
+    @apply bg-gray-100 text-gray-900;
+    --btn-primary-bg: #6b7280; /* gray-500 */
+    --btn-primary-hover: #4b5563; /* gray-600 */
+    --btn-secondary-bg: #e5e7eb; /* gray-200 */
+    --btn-secondary-hover: #d1d5db; /* gray-300 */
+    --btn-secondary-text: #374151; /* gray-700 */
   }
 }
 
 @layer components {
-  .btn-primary {
-    @apply inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500;
+  .btn {
+    @apply inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm transition-colors;
   }
-  
+
+  .btn-primary {
+    @apply btn text-white;
+    background-color: var(--btn-primary-bg);
+  }
+  .btn-primary:hover {
+    background-color: var(--btn-primary-hover);
+  }
+
   .btn-secondary {
-    @apply inline-flex items-center justify-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500;
+    @apply btn;
+    color: var(--btn-secondary-text);
+    background-color: var(--btn-secondary-bg);
+  }
+  .btn-secondary:hover {
+    background-color: var(--btn-secondary-hover);
   }
 
   .card {
     @apply bg-white rounded-lg shadow-md p-6;
   }
-} 
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,7 @@ export default function LandingPage() {
             <div className="mt-10 flex items-center justify-center gap-x-6">
               <Link
                 href="/auth/signup"
-                className="rounded-md bg-blue-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+                className="btn btn-primary"
               >
                 Start Now
               </Link>
@@ -97,7 +97,7 @@ export default function LandingPage() {
             <div className="mt-10 flex items-center justify-center gap-x-6">
               <Link
                 href="/auth/signup"
-                className="rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                className="btn btn-secondary"
               >
                 Get started
               </Link>

--- a/src/components/AIChatbotPanel.tsx
+++ b/src/components/AIChatbotPanel.tsx
@@ -8,7 +8,7 @@ export default function AIChatbotPanel() {
         placeholder="Ask me anything..."
         className="mt-4 w-full px-3 py-2 border border-gray-300 rounded-md"
       />
-      <button className="mt-2 px-4 py-2 bg-blue-600 text-white rounded-md">
+      <button className="mt-2 btn btn-primary">
         Send
       </button>
       {/* Add AI chatbot logic here */}

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -68,7 +68,7 @@ export default function ChatPanel() {
       {!isOpen ? (
         <button
           onClick={() => setIsOpen(true)}
-          className="bg-blue-600 text-white rounded-full p-4 shadow-lg hover:bg-blue-700 transition-colors"
+          className="btn btn-primary rounded-full p-4 shadow-lg"
           aria-label="Open chat"
         >
           <svg
@@ -155,10 +155,10 @@ export default function ChatPanel() {
               <button
                 type="submit"
                 disabled={isLoading || !input.trim()}
-                className={`bg-blue-600 text-white rounded-lg px-4 py-2 transition-colors ${
+                className={`btn btn-primary rounded-lg ${
                   isLoading || !input.trim()
                     ? 'opacity-50 cursor-not-allowed'
-                    : 'hover:bg-blue-700'
+                    : ''
                 }`}
               >
                 Send

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -53,7 +53,7 @@ export default function Navigation() {
                 </Link>
                 <Link
                   href="/auth/signup"
-                  className="px-4 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-500"
+                  className="btn btn-primary"
                 >
                   Sign up
                 </Link>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -2,8 +2,37 @@
 
 import { useState, useEffect } from 'react'
 
-const themes = ['light', 'grey', 'dark'] as const
+function SunIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <circle cx="12" cy="12" r="5" />
+      <path d="M12 1v2m0 18v2m9-11h-2M5 12H3m15.364-8.364l-1.414 1.414M6.05 17.95l-1.414 1.414M18.364 17.95l-1.414-1.414M6.05 6.05L4.636 4.636" />
+    </svg>
+  )
+}
+
+function MoonIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
+    </svg>
+  )
+}
+
+function CloudMoonIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z" />
+      <path d="M3 15a4 4 0 008 0h1a5 5 0 0010 0 5 5 0 00-9.33-2.67A5 5 0 003 15z" />
+    </svg>
+  )
+}
+
+const themes = ['light', 'dark', 'grey'] as const
 export type Theme = typeof themes[number]
+
+const icons = [SunIcon, MoonIcon, CloudMoonIcon]
+const iconColors = ['text-yellow-500', 'text-black', 'text-gray-500']
 
 function applyTheme(theme: Theme) {
   document.documentElement.classList.remove('theme-light', 'theme-grey', 'theme-dark')
@@ -31,9 +60,16 @@ export default function ThemeToggle() {
     applyTheme(themes[next])
   }
 
+  const Icon = icons[index]
+  const color = iconColors[index]
+
   return (
-    <button onClick={handleClick} className="text-gray-600 hover:text-gray-900" aria-label="Toggle theme">
-      {themes[index].charAt(0).toUpperCase() + themes[index].slice(1)}
+    <button
+      onClick={handleClick}
+      aria-label="Toggle theme"
+      className={`p-2 ${color}`}
+    >
+      <Icon className="h-6 w-6" />
     </button>
   )
 }


### PR DESCRIPTION
## Summary
- overhaul theme styles and add CSS variables
- use `btn` classes for shared button styling
- show icon-based theme toggle cycling light, dark and gray modes
- integrate new button styles across components

## Testing
- `npm run build` *(fails: connect EHOSTUNREACH)*